### PR TITLE
Swap out ubuntu base image with mini/base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
-FROM ubuntu:trusty
+FROM mini/base
 MAINTAINER Jeff Lindsay <progrium@gmail.com>
 
-RUN echo "deb http://ppa.launchpad.net/nginx/stable/ubuntu trusty main" > /etc/apt/sources.list.d/nginx.list
-
-RUN apt-get update && apt-get install -y --force-yes nginx ruby1.9.1
+RUN apk update && apk-install bash nginx ruby ruby-json
 RUN rm -rf /etc/nginx/conf.d /etc/nginx/sites-available /etc/nginx/sites-enabled
 RUN echo "include /etc/nginx/docker.include; events { }" > /etc/nginx/nginx.conf
 
-ADD https://github.com/progrium/configurator/releases/download/v0.0.2/configurator_0.0.2_linux_x86_64.tgz /tmp/configurator.tgz
+ADD https://github.com/progrium/configurator/releases/download/v0.0.3/configurator_0.0.3_linux_x86_64.tgz /tmp/configurator.tgz
 RUN cd /bin && tar -zxf /tmp/configurator.tgz && rm /tmp/configurator.tgz
 
-ADD https://raw.githubusercontent.com/progrium/configurator/v0.0.2/transformers/nginx-conf /bin/nginx-conf
+ADD https://raw.githubusercontent.com/progrium/configurator/v0.0.3/transformers/nginx-conf /bin/nginx-conf
 RUN chmod +x /bin/nginx-conf
+RUN mkdir -p /tmp/nginx
 
 ADD ./docker.include /etc/nginx/docker.include
 ADD ./default.json /tmp/default.json

--- a/default.json
+++ b/default.json
@@ -2,7 +2,7 @@
   "include": "/etc/nginx/docker.include",
   "user": ["nobody", "nogroup"],
   "worker_processes": 4,
-  "pid": "/run/nginx.pid",
+  "pid": "/var/run/nginx.pid",
   "events": {
     "worker_connections": 768
   },
@@ -22,7 +22,7 @@
           "80": ["default_server"],
           "[::]:80": ["default_server", "ipv6only=on"]
         },
-        "root": "/usr/share/nginx/html",
+        "root": "/usr/html",
         "index": ["index.html", "index.htm"],
         "server_name": "localhost",
         "location": {


### PR DESCRIPTION
Hey Jeff,

Thanks for this project (and the plethora of others!) - love the clarity of your blog too. 

I've dropped in mini/base (an Alpine Linux distro), made a few config adjustments, and added configurator v0.0.3. The net result is an image that hovers around 33 MB. :) Addresses the concerns raised in https://github.com/progrium/nginx-appliance/issues/1.

(Nginx version is 1.6.2)

Cheers,
Phil
